### PR TITLE
feat: Add visual analysis agent and basic orchestrator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,16 +32,20 @@ The project uses:
 ### Running the System
 
 ```bash
-# Main entry point for static analysis (from project root)
-uv run python -m pdf_hunter.agents.static_analysis.graph
+# Run the orchestrator (coordinates preprocessing and visual analysis)
+uv run python -m pdf_hunter.orchestrator.graph
 
-# Main entry point for preprocessing
+# Run individual agents
 uv run python -m pdf_hunter.agents.preprocessing.graph
+uv run python -m pdf_hunter.agents.visual_analysis.graph
+uv run python -m pdf_hunter.agents.static_analysis.graph
 
 # Alternative with editable install
 uv pip install -e .
-python -m pdf_hunter.agents.static_analysis.graph
+python -m pdf_hunter.orchestrator.graph
 python -m pdf_hunter.agents.preprocessing.graph
+python -m pdf_hunter.agents.visual_analysis.graph
+python -m pdf_hunter.agents.static_analysis.graph
 
 # Jupyter development
 jupyter lab notebooks/development/
@@ -54,7 +58,8 @@ jupyter lab notebooks/development/
 **Orchestrator** (`src/pdf_hunter/orchestrator/`):
 
 - Master coordination graph that manages the entire analysis workflow
-- Currently placeholder with minimal implementation
+- Currently in a basic testing state, coordinating preprocessing and visual analysis agents
+- Not final and may change in future iterations
 
 **Preprocessing Agent** (`src/pdf_hunter/agents/preprocessing/`):
 
@@ -62,6 +67,13 @@ jupyter lab notebooks/development/
 - **Initialization Node**: Validates paths, calculates file hashes, and gets page count
 - **Image Extraction Node**: Extracts images from pages, calculates perceptual hashes
 - **URL Extraction Node**: Extracts URLs from annotations and text
+
+**Visual Analysis Agent** (`src/pdf_hunter/agents/visual_analysis/`):
+
+- Analyzes PDF pages visually for deceptive tactics and benign signals
+- **Visual Analysis Node**: Examines extracted images and URLs for visual deception
+- **Aggregation Node**: Combines page-level analyses into a comprehensive report
+- Identifies deception tactics, benign signals, and prioritizes URLs for deeper analysis
 
 **Static Analysis Agent** (`src/pdf_hunter/agents/static_analysis/`):
 
@@ -92,16 +104,20 @@ jupyter lab notebooks/development/
 **Investigation Mission**: Single-focused tasks with threat types (OpenAction, JavaScript, AcroForm, etc.)
 **Evidence Graph**: Nodes (PDF objects, artifacts, IOCs) and edges (relationships) representing the attack chain
 **Mission Report**: Structured findings from individual investigations
+**Visual Analysis Report**: Structured findings from visual analysis including deception tactics and benign signals
 **Final Report**: Executive summary, attack chain reconstruction, and IOCs
 
 ### Agent Workflow
 
 1. **Preprocessing**: Extract basic data from PDF (images, URLs, hashes)
-2. **Triage**: Scan PDF with multiple tools, classify as innocent/suspicious, generate missions
-3. **Mission Dispatch**: Parallel investigation of specific threats
-4. **Investigation**: Tool-assisted deep analysis of PDF objects and content
-5. **Review**: Evidence graph merging, strategic assessment, additional mission generation
-6. **Finalization**: Comprehensive report with verdict and actionable intelligence
+2. **Visual Analysis**: Analyze extracted images and URLs for visual deception tactics
+3. **Triage**: Scan PDF with multiple tools, classify as innocent/suspicious, generate missions
+4. **Mission Dispatch**: Parallel investigation of specific threats
+5. **Investigation**: Tool-assisted deep analysis of PDF objects and content
+6. **Review**: Evidence graph merging, strategic assessment, additional mission generation
+7. **Finalization**: Comprehensive report with verdict and actionable intelligence
+
+The orchestrator currently coordinates steps 1-2 (preprocessing and visual analysis).
 
 ## Configuration
 
@@ -133,6 +149,7 @@ OPENAI_API_KEY=your_key_here
 - `notebooks/development/preprocessing.ipynb`: Preprocessing development and testing notebook
 - Contains step-by-step agent execution and debugging
 - Use for prototyping new features before integrating into main codebase
+- Visual analysis and orchestrator development typically done directly in Python modules
 
 ## File Organization
 
@@ -150,7 +167,10 @@ src/
     │   │   ├── schemas.py       # State and data models
     │   │   ├── prompts.py       # LLM prompts for each node
     │   │   └── tools.py         # LangChain tool implementations
-    │   └── visual_analysis/     # Placeholder for future visual analysis
+    │   └── visual_analysis/     # Visual analysis agent implementation
+    │       ├── graph.py         # LangGraph workflow definition
+    │       ├── nodes.py         # Individual workflow nodes
+    │       └── schemas.py       # State and data models
     ├── orchestrator/            # Master coordination
     │   ├── graph.py             # Main orchestrator workflow
     │   ├── nodes.py             # Orchestrator nodes
@@ -184,7 +204,8 @@ tests/                       # PDF samples and test data
 └── *.pdf                    # Sample PDF files
 
 output/                      # Generated analysis reports
-└── preprocessing_results/   # Results from preprocessing agent
+├── preprocessing_results/   # Results from preprocessing agent
+└── orchestrator_results/    # Results from orchestrator-coordinated analysis
 ```
 
 ## Development Patterns

--- a/langgraph.json
+++ b/langgraph.json
@@ -2,7 +2,8 @@
     "dependencies": ["."],
     "graphs": {
       "static_analysis": "pdf_hunter.agents.static_analysis.graph:static_analysis_graph",
-      "preprocessing": "pdf_hunter.agents.preprocessing.graph:preprocessing_graph"
+      "preprocessing": "pdf_hunter.agents.preprocessing.graph:preprocessing_graph",
+      "orchestrator": "pdf_hunter.orchestrator.graph:orchestrator_graph"
     },
     "env": ".env"
   }

--- a/src/pdf_hunter/agents/visual_analysis/graph.py
+++ b/src/pdf_hunter/agents/visual_analysis/graph.py
@@ -1,0 +1,64 @@
+from langgraph.graph import StateGraph, START, END
+
+from .schemas import VisualAnalysisState
+from .nodes import visual_analysis_node, aggregation_node
+
+
+visual_analysis_builder = StateGraph(VisualAnalysisState)
+
+visual_analysis_builder.add_node("visual_analysis", visual_analysis_node)
+visual_analysis_builder.add_node("aggregate_report", aggregation_node)
+
+visual_analysis_builder.add_edge(START, "visual_analysis")
+
+visual_analysis_builder.add_edge("visual_analysis", "aggregate_report")
+
+visual_analysis_builder.add_edge("aggregate_report", END)
+
+visual_analysis_graph = visual_analysis_builder.compile()
+
+
+if __name__ == "__main__":
+    import pprint
+    from ..preprocessing.graph import preprocessing_graph
+
+    file_path = "/Users/gorelik/Courses/pdf-hunter/tests/test_mal_one.pdf"
+    output_directory = "output/visual_analysis_results"
+    pages_to_process = 1
+
+    print(f"--- Running Preprocessing on: {file_path} ---")
+    preprocessing_input = {
+        "file_path": file_path,
+        "output_directory": output_directory,
+        "number_of_pages_to_process": 1,
+    }
+    preprocessing_results = preprocessing_graph.invoke(preprocessing_input)
+    
+    if preprocessing_results.get("errors"):
+        print("\n--- Preprocessing Failed ---")
+        pprint.pprint(preprocessing_results["errors"])
+    else:
+        print("\n--- Preprocessing Succeeded. Preparing for Visual Analysis... ---")
+
+        visual_analysis_input = {
+            "extracted_images": preprocessing_results["extracted_images"],
+            "extracted_urls": preprocessing_results["extracted_urls"],
+            "number_of_pages_to_process": 1
+        }
+
+        print(f"\n--- Running Visual Analysis on {pages_to_process} page(s) ---")
+        
+        final_state = visual_analysis_graph.invoke(visual_analysis_input)
+
+        print("\n--- Visual Analysis Complete. ---")
+
+        if final_state.get("errors"):
+            print("\n--- Visual Analysis Failed ---")
+            pprint.pprint(final_state["errors"])
+        else:
+            visual_analysis_report = final_state.get("visual_analysis_report")
+            if visual_analysis_report:
+                print("\n--- Final Report ---")
+                pprint.pprint(visual_analysis_report.model_dump())
+            else:
+                print("ERROR: Final report was not generated.")

--- a/src/pdf_hunter/agents/visual_analysis/nodes.py
+++ b/src/pdf_hunter/agents/visual_analysis/nodes.py
@@ -1,0 +1,190 @@
+# src/pdf_hunter/agents/visual_analysis/nodes.py
+
+import json
+from typing import List
+
+from langchain_core.messages import SystemMessage, HumanMessage
+
+from .schemas import VisualAnalysisState, PageAnalysisResult, VisualAnalysisReport
+from .prompts import VISUAL_ANALYSIS_SYSTEM_PROMPT, VISUAL_ANALYSIS_USER_PROMPT
+from pdf_hunter.config import visual_analysis_llm
+
+llm_with_structured_output = visual_analysis_llm.with_structured_output(PageAnalysisResult)
+
+
+def _create_structured_forensic_briefing(page_result: PageAnalysisResult) -> str:
+    """
+    Creates a concise, yet detailed, briefing of the previous page's analysis
+    to be used as context for the next page.
+    """
+    # Find the page number from the first detailed finding, if available.
+    page_num = -1 
+    if page_result.detailed_findings:
+        page_num = page_result.detailed_findings[0].page_number
+
+    briefing = [
+        f"Context from the previous page (Page {page_num}):",
+        f"- Page Appearance: {page_result.page_description}",
+        f"- Overall Verdict: {page_result.visual_verdict} (Confidence: {page_result.confidence_score:.2f})",
+        f"- Summary: {page_result.summary}"
+    ]
+
+    # Filter for only the most significant forensic findings to pass as context.
+    high_significance_findings = [
+        f for f in page_result.detailed_findings if f.significance == "high"
+    ]
+
+    if high_significance_findings:
+        briefing.append("- Key Forensic Findings:")
+        for finding in high_significance_findings:
+            # Extract the most critical piece of technical data (like a URL) for the briefing.
+            tech_data_summary = ""
+            if finding.technical_data and 'url' in finding.technical_data:
+                tech_data_summary = f" (URL: '{finding.technical_data['url']}')"
+            
+            briefing.append(f"  * {finding.assessment}{tech_data_summary}")
+    
+    return "\n".join(briefing)
+
+
+def visual_analysis_node(state: VisualAnalysisState):
+    """
+    Performs a sequential, context-aware visual analysis of each page.
+    """
+    print("--- Visual Analysis Node: Starting Page-by-Page Analysis ---")
+    
+    try:
+        num_pages_to_process = state.get("number_of_pages_to_process", 1)
+        all_images = state['extracted_images']
+        all_urls = state['extracted_urls']
+
+        images_to_process = sorted(
+            [img for img in all_images if img.page_number < num_pages_to_process],
+            key=lambda img: img.page_number
+        )
+        
+        if not images_to_process:
+            print("[WARNING] No images found for the requested page range.")
+            return {"page_analyses": []}
+
+        page_analyses_results: List[PageAnalysisResult] = []
+        previous_pages_context = "This is the first page. There is no prior context."
+
+        for image in images_to_process:
+            page_num = image.page_number
+            print(f"[*] Analyzing Page {page_num}...")
+
+            urls_for_this_page = [url for url in all_urls if url.page_number == page_num]
+            element_map = {
+                "page_number": page_num,
+                "interactive_elements": [url.model_dump() for url in urls_for_this_page]
+            }
+
+            # Format the user prompt with the context and element map.
+            formatted_user_prompt = VISUAL_ANALYSIS_USER_PROMPT.format(
+                element_map_json=json.dumps(element_map, indent=2),
+                previous_pages_context=previous_pages_context
+            )
+            
+            # Construct the full, correct list of messages for the LLM call.
+            messages = [
+                SystemMessage(content=VISUAL_ANALYSIS_SYSTEM_PROMPT),
+                HumanMessage(
+                    content=[
+                        {"type": "text", "text": formatted_user_prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": f"data:image/png;base64,{image.base64_data}"}
+                        }
+                    ]
+                )
+            ]
+
+            # Invoke the LLM with the correct message structure.
+            page_result = llm_with_structured_output.invoke(messages)
+            page_analyses_results.append(page_result)
+            print(f"--- Page {page_num} Verdict: {page_result.visual_verdict} (Confidence: {page_result.confidence_score:.2f})")
+
+            # Generate the rich, structured briefing for the next iteration.
+            previous_pages_context = _create_structured_forensic_briefing(page_result)
+        
+        return {"page_analyses": page_analyses_results}
+
+    except Exception as e:
+        error_msg = f"An unexpected error occurred during visual analysis: {e}"
+        print(f"[ERROR] {error_msg}")
+        return {"errors": [error_msg]}
+
+
+def aggregation_node(state: VisualAnalysisState):
+    """
+    Aggregates all page-level analyses into a final, conclusive report using
+    robust, programmatic logic.
+    """
+    print("--- Visual Analysis Node: Aggregating Final Report ---")
+    page_analyses = state.get("page_analyses", [])
+
+    if not page_analyses:
+        print("[INFO] No page analyses were performed. Generating empty report.")
+        # Correctly instantiate the report with keywords to prevent TypeError.
+        visual_analysis_report = VisualAnalysisReport(
+            overall_verdict="Benign",
+            overall_confidence=1.0,
+            document_flow_summary="No pages were analyzed.",
+            executive_summary="No pages were analyzed, so no threats were detected.",
+            page_analyses=[],
+            all_detailed_findings=[],
+            all_deception_tactics=[],
+            all_benign_signals=[],
+            high_priority_urls=[]
+        )
+        return {"visual_analysis_report": visual_analysis_report}
+
+    # Ensure pages are sorted for a logical flow summary.
+    sorted_analyses = sorted(page_analyses, key=lambda p: p.detailed_findings[0].page_number if p.detailed_findings else 0)
+
+    # --- Generate the Document Flow Summary ---
+    flow_steps = []
+    for analysis in sorted_analyses:
+        page_num = analysis.detailed_findings[0].page_number if analysis.detailed_findings else 'N/A'
+        flow_steps.append(f"Page {page_num}: {analysis.page_description}")
+    document_flow_summary = "\n".join(flow_steps)
+    
+    # Determine Overall Verdict based on the most severe finding.
+    verdict_severity = {"Benign": 0, "Suspicious": 1, "Highly Deceptive": 2}
+    most_severe_verdict = max(page_analyses, key=lambda p: verdict_severity[p.visual_verdict]).visual_verdict
+
+    # Correctly calculate Overall Confidence based on the "weakest link" principle.
+    pages_with_highest_threat = [p for p in page_analyses if p.visual_verdict == most_severe_verdict]
+    overall_confidence = max(p.confidence_score for p in pages_with_highest_threat)
+
+    # Aggregate all findings into flat lists for the final report.
+    all_detailed_findings = [finding for p in page_analyses for finding in p.detailed_findings]
+    all_tactics = [tactic for p in page_analyses for tactic in p.deception_tactics]
+    all_signals = [signal for p in page_analyses for signal in p.benign_signals]
+    all_priority_urls = [url for p in page_analyses for url in p.prioritized_urls]
+    high_priority_urls = [url for url in all_priority_urls if url.priority <= 2]
+
+    # Generate the Executive Summary.
+    summary = (
+        f"Visual analysis of {len(page_analyses)} page(s) resulted in an overall verdict of '{most_severe_verdict}'.\n"
+        f"The analysis produced {len(all_detailed_findings)} specific forensic findings, "
+        f"which were summarized into {len(all_tactics)} deception tactics and {len(all_signals)} benign signals.\n"
+        f"Flagged {len(high_priority_urls)} high-priority URLs for further investigation."
+    )
+
+    # Construct the final report object.
+    visual_analysis_report = VisualAnalysisReport(
+        overall_verdict=most_severe_verdict,
+        overall_confidence=overall_confidence,
+        document_flow_summary=document_flow_summary,
+        executive_summary=summary,
+        page_analyses=page_analyses,
+        all_detailed_findings=all_detailed_findings,
+        all_deception_tactics=all_tactics,
+        all_benign_signals=all_signals,
+        high_priority_urls=high_priority_urls
+    )
+    
+    print(f"--- Final Verdict: {visual_analysis_report.overall_verdict} (Confidence: {visual_analysis_report.overall_confidence:.2f}) ---")
+    return {"visual_analysis_report": visual_analysis_report}

--- a/src/pdf_hunter/agents/visual_analysis/prompts.py
+++ b/src/pdf_hunter/agents/visual_analysis/prompts.py
@@ -1,0 +1,68 @@
+VISUAL_ANALYSIS_SYSTEM_PROMPT = """
+**You are the Visual Deception Analyst (VDA).** Your persona is a unique synthesis of three experts: a **Human-Computer Interaction (HCI) & UI/UX Security specialist**, a **Cognitive Psychologist** who understands social engineering, and a **Digital Forensics analyst**.
+
+Your core philosophy is this: **autonomy is disease, deception is confession, and incoherence is a symptom.** Your mission is to judge a document's trustworthiness by assessing its **holistic integrity**. You must be an impartial judge, actively searching for evidence of **legitimacy (coherence)** with the same diligence that you hunt for evidence of **deception (incoherence)**.
+
+You will analyze the rendered visual layer of a PDF to unmask malicious intent, focusing on *why* a design is deceptive while also recognizing signals of genuine authenticity.
+
+---
+
+### **I. The Case File (Your Inputs)**
+
+You will receive two pieces of evidence:
+1.  **The Visual Evidence:** A high-resolution PNG image of the PDF page.
+2.  **The Technical Blueprint:** A structured JSON "Element Map" containing the bounding box, text, and destination URL for every interactive element (links, buttons) found by the static parser.
+3.  **Forensic Context from Previous Pages:** A briefing summarizing the findings from any pages analyzed before this one.
+---
+
+### **II. The Core Analytical Framework (Your Reasoning Process)**
+
+Your primary task is a **rigorous, two-sided cross-examination**. Guide your analysis with these high-level questions:
+
+**Part A: Hunting for Incoherence (Signs of Deception)**
+
+*   **1. Identity & Brand Impersonation:** Is there a contradiction between the *visual brand* and the *technical data*? (e.g., a professional logo paired with a suspicious, non-official URL). Does the branding on this page contradict the branding seen on previous pages?
+*   **2. Psychological Manipulation:** Does the design use powerful emotional levers like **Urgency**, **Fear**, or **Authority** to bypass rational thought? Are "dark patterns" used to make the malicious path the most prominent?
+*   **3. Interactive Element Deception:** Is there a mismatch between what a link or button *says* it does and where its URL *actually goes*? Are trusted OS/app interfaces being mimicked by simple, hyperlinked images?
+*   **4. Structural Deception:** Does the document's structure contradict its appearance (e.g., looks like a scan but has perfect vector text)?
+
+**Part B: Searching for Coherence (Signs of Legitimacy)**
+
+*   **5. Holistic Consistency & Professionalism:** This is your primary counter-argument.
+    *   Is there a high degree of **internal consistency** across the entire document? Does the branding, design language, and professional tone remain constant throughout?
+    *   Is there **visual-technical coherence**? Do the URLs for *all* major interactive elements align logically with their visual representation and the document's purported purpose?
+    *   Does the document exhibit signs of **transparency and good faith**, such as clear, non-obfuscated links and an absence of high-pressure sales or fear tactics?
+
+---
+
+### **III. The Forensic Report (Your Output)**
+
+Your analysis must be captured in a **rich, structured JSON object** that conforms to the `PageAnalysisResult` schema.
+Your final verdict must be a synthesis of how you weighed the evidence from both Part A and Part B, considering all available context.
+
+**A key requirement is for the `technical_data` field within a `DetailedFinding`. This field MUST be a JSON-formatted string.** For example, if a link is deceptive, its technical data should be represented as `'{\"url\": \"http://bad-domain.com\", \"xref\": 55}'`. If there is no technical data, the value should be `null`.
+
+**CRITICAL:** Your report must be for the **CURRENT PAGE ONLY**. Do not include findings from previous pages in your output. Use the previous page context for your reasoning, but report only on what you see on the current page.
+"""
+
+VISUAL_ANALYSIS_USER_PROMPT = """
+I need you to analyze the following PDF page for visual deception tactics.
+
+---
+**Forensic Context from Previous Pages:**
+{previous_pages_context}
+---
+**Technical Blueprint (Element Map for CURRENT page):**
+```json
+{element_map_json}
+```
+
+**Your Mission:**
+
+1. **Review the Forensic Context:** Understand the findings from the pages that came before this one.
+2. **Examine the Visual Evidence:** Analyze the attached image of the **current page**.
+3. **Cross-Reference the Technical Blueprint:** Compare what you see in the image with the structured data provided for the current page.
+4. **Synthesize and Decide:** Based on all available information (previous context, current image, and current technical data), perform your full analysis as per your system instructions.
+
+Provide your complete analysis for the **CURRENT PAGE ONLY** in the required `PageAnalysisResult` JSON format.
+"""

--- a/src/pdf_hunter/agents/visual_analysis/schemas.py
+++ b/src/pdf_hunter/agents/visual_analysis/schemas.py
@@ -1,0 +1,95 @@
+import operator
+from typing import List, Dict, Optional, Literal
+from pydantic import BaseModel, Field
+from typing_extensions import TypedDict, Annotated, NotRequired
+
+from ..preprocessing.schemas import ExtractedImage, ExtractedURL
+
+
+class DeceptionTactic(BaseModel):
+    """Information about a detected deception tactic."""
+    tactic_type: str = Field(..., description="Type of deception tactic identified.")
+    description: str = Field(..., description="Detailed description of the tactic.")
+    confidence: float = Field(..., description="Confidence in detection (0.0-1.0).")
+    evidence: List[str] = Field(default_factory=list, description="Supporting evidence for this tactic")
+
+class BenignSignal(BaseModel):
+    """Information about a detected benign/legitimate signal."""
+    signal_type: str = Field(..., description="Type of benign signal.")
+    description: str = Field(..., description="Detailed description of the signal.")
+    confidence: float = Field(..., description="Confidence in assessment (0.0-1.0).")
+
+class PrioritizedURL(BaseModel):
+    """A URL marked for deeper analysis by downstream agents."""
+    url: str = Field(..., description="The URL requiring analysis.")
+    priority: int = Field(..., description="Priority level (1=highest, 5=lowest).")
+    reason: str = Field(..., description="Reason for the priority assessment.")
+    page_number: int = Field(..., description="The page number (0-indexed) where this URL was most prominently found.")
+
+
+class DetailedFinding(BaseModel):
+    """A specific finding from visual-technical cross-examination."""
+    element_type: str = Field(..., description="Type of element (link, button, logo, etc.)")
+    page_number: int = Field(..., description="Page number where finding was observed", ge=0)
+    visual_description: str = Field(..., description="Description of visual appearance")
+    technical_data: Optional[str] = Field(None, description="A JSON-formatted string containing relevant technical data (e.g., '{\"url\": \"http://...\", \"xref\": 15}'). Should be null if no technical data is relevant.")
+    assessment: str = Field(..., description="Assessment of this finding")
+    significance: Literal["low", "medium", "high"] = Field(..., description="Significance level of this finding")
+
+
+class PageAnalysisResult(BaseModel):
+    """
+    The structured output from the visual analysis of a SINGLE page.
+    This is the contract for our LLM's page-level analysis.
+    """
+    page_description: str = Field(..., description="A brief, objective description of the page's overall appearance, layout, and apparent purpose (e.g., 'A professional-looking corporate invoice with a prominent payment button.').")
+    detailed_findings: List[DetailedFinding] = Field(
+        default_factory=list, description="Specific cross-modal analysis findings"
+    )
+    deception_tactics: List[DeceptionTactic] = Field(default_factory=list, description="Identified deception techniques")
+    benign_signals: List[BenignSignal] = Field(default_factory=list, description="Identified legitimacy indicators")
+    prioritized_urls: List[PrioritizedURL] = Field(default_factory=list, description="URLs requiring deeper analysis")
+    visual_verdict: Literal["Benign", "Suspicious", "Highly Deceptive"] = Field(..., description="Final visual trustworthiness judgment for this page")
+    confidence_score: float = Field(..., description="Confidence in the verdict for this page (0.0-1.0).")
+    summary: str = Field(..., description="Concise summary explaining conclusion and evidence weighting for this page")
+    
+
+
+class VisualAnalysisReport(BaseModel):
+    """The complete and final output of the visual analysis agent, created by aggregating all page-level results."""
+    overall_verdict: Literal["Benign", "Suspicious", "Highly Deceptive"]
+    overall_confidence: float
+    executive_summary: str
+
+    document_flow_summary: str = Field(..., description="A summary of the document's structure, describing the purpose of each page in sequence.")
+    
+    page_analyses: List[PageAnalysisResult]
+    
+    all_detailed_findings: List[DetailedFinding]
+    all_deception_tactics: List[DeceptionTactic]
+    all_benign_signals: List[BenignSignal]
+    high_priority_urls: List[PrioritizedURL]
+
+
+class VisualAnalysisState(TypedDict):
+    """
+    State for the Visual Analysis agent.
+    """
+    extracted_images: List[ExtractedImage]
+    extracted_urls: List[ExtractedURL]
+    number_of_pages_to_process: int
+    page_analyses: List[PageAnalysisResult]
+    visual_analysis_report: NotRequired[VisualAnalysisReport]
+    errors: Annotated[List[str], operator.add]
+
+
+class VisualAnalysisInputState(TypedDict):
+    extracted_images: List[ExtractedImage]
+    extracted_urls: List[ExtractedURL]
+    number_of_pages_to_process: int
+
+
+class VisualAnalysisOutputState(TypedDict):
+    page_analyses: List[PageAnalysisResult]
+    visual_analysis_report: VisualAnalysisReport
+    errors: Annotated[List[str], operator.add]

--- a/src/pdf_hunter/orchestrator/graph.py
+++ b/src/pdf_hunter/orchestrator/graph.py
@@ -1,1 +1,94 @@
-# Master graph that coordinates agents
+from langgraph.graph import StateGraph, START, END
+
+from .schemas import OrchestratorState, OrchestratorInputState
+from ..agents.preprocessing.graph import preprocessing_graph
+from ..agents.visual_analysis.graph import visual_analysis_graph
+
+
+orchestrator_builder = StateGraph(OrchestratorState, input_schema=OrchestratorInputState)
+
+orchestrator_builder.add_node("preprocessing", preprocessing_graph)
+orchestrator_builder.add_node("visual_analysis", visual_analysis_graph)
+orchestrator_builder.add_edge(START, "preprocessing")
+
+orchestrator_builder.add_edge("preprocessing", "visual_analysis")
+
+orchestrator_builder.add_edge("visual_analysis", END)
+
+orchestrator_graph = orchestrator_builder.compile()
+
+
+if __name__ == "__main__":
+    import pprint
+    import uuid
+    import json
+    import os
+    from datetime import datetime
+
+    file_path = "/Users/gorelik/Courses/pdf-hunter/tests/test_mal_one.pdf"
+    output_directory = "output/orchestrator_results"
+    number_of_pages_to_process = 1
+
+    orchestrator_input = {
+        "file_path": file_path,
+        "output_directory": output_directory,
+        "number_of_pages_to_process": number_of_pages_to_process
+    }
+    
+    print("--- STARTING PDF HUNTER ORCHESTRATOR ---")
+    
+    final_state = None
+    # Invoke the entire orchestrator with the initial state.
+    final_state = orchestrator_graph.invoke(orchestrator_input)
+
+    print("\n\n--- PDF HUNTER ORCHESTRATOR COMPLETE ---")
+    print("\n--- Final State of the Hunt: ---")
+    
+    def pretty_print_state(state):
+        printable_state = {}
+        for key, value in state.items():
+            if hasattr(value, 'model_dump'):
+                printable_state[key] = value.model_dump()
+            else:
+                printable_state[key] = value
+        pprint.pprint(printable_state)
+
+    pretty_print_state(final_state)
+
+    visual_analysis_report = final_state.get("visual_analysis_report")
+    if visual_analysis_report:
+        print("\n--- Visual Analysis Verdict ---")
+        print(f"Verdict: {visual_analysis_report.overall_verdict}")
+        print(f"Confidence: {visual_analysis_report.overall_confidence}")
+
+    # Save final state to JSON file
+    if final_state:
+        # Generate unique filename with timestamp
+        unique_id = uuid.uuid4().hex[:8]
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"analysis_report_session_{unique_id}_{timestamp}.json"
+        
+        # Ensure output directory exists
+        os.makedirs(output_directory, exist_ok=True)
+        
+        # Full path for the JSON file
+        json_path = os.path.join(output_directory, filename)
+        
+        # Convert final state to JSON-serializable format
+        def make_serializable(obj):
+            if hasattr(obj, 'model_dump'):
+                return obj.model_dump()
+            elif isinstance(obj, dict):
+                return {k: make_serializable(v) for k, v in obj.items()}
+            elif isinstance(obj, list):
+                return [make_serializable(item) for item in obj]
+            else:
+                return obj
+        
+        serializable_state = make_serializable(final_state)
+        
+        # Save to JSON file
+        with open(json_path, 'w', encoding='utf-8') as f:
+            json.dump(serializable_state, f, indent=2, ensure_ascii=False)
+        
+        print(f"\n--- Final state saved to: {json_path} ---")

--- a/src/pdf_hunter/orchestrator/nodes.py
+++ b/src/pdf_hunter/orchestrator/nodes.py
@@ -1,1 +1,0 @@
-# Agent dispatcher, result aggregator

--- a/src/pdf_hunter/orchestrator/schemas.py
+++ b/src/pdf_hunter/orchestrator/schemas.py
@@ -1,1 +1,38 @@
-# Orchestrator state, agent selection
+from typing import List, Optional
+from typing_extensions import TypedDict, NotRequired, Annotated
+import operator
+
+
+from ..agents.preprocessing.schemas import ExtractedImage, ExtractedURL
+from ..agents.visual_analysis.schemas import VisualAnalysisReport
+from ..agents.preprocessing.schemas import PDFHashData
+
+class OrchestratorState(TypedDict):
+    """
+    The master state for the PDF-Hunter orchestrator.
+    It holds the initial inputs and collects the final reports from all sub-agents.
+    """
+    # --- Initial User Inputs ---
+    file_path: str
+    output_directory: str
+    number_of_pages_to_process: int
+    pages_to_process: Optional[List[int]]
+
+    pdf_hash: Optional[PDFHashData]
+    page_count: Optional[int]
+
+    # --- Results from Preprocessing Agent ---
+    extracted_images: List[ExtractedImage]
+    extracted_urls: List[ExtractedURL]
+
+    # --- Results from Visual Analysis Agent ---
+    visual_analysis_report: NotRequired[VisualAnalysisReport]
+    
+    # --- Global Error Tracking ---
+    errors: Annotated[List[list], operator.add]
+
+
+class OrchestratorInputState(TypedDict):
+    file_path: str
+    output_directory: str
+    number_of_pages_to_process: int


### PR DESCRIPTION
This commit introduces two major components:

1. Visual Analysis Agent:
   - Analyzes PDF pages for visual deception tactics and benign signals
   - Includes visual analysis and aggregation nodes
   - Produces structured reports with deception tactics, benign signals, and prioritized URLs
   - Implements a cross-modal analysis approach comparing visual elements with technical data

2. Basic Orchestrator:
   - Coordinates preprocessing and visual analysis agents
   - Implements a simple sequential workflow
   - Saves analysis results to JSON files
   - Note: This is a testing implementation that may change in future iterations

Additional changes:
- Updated CLAUDE.md with documentation for the new components
- Updated langgraph.json to register the orchestrator graph
- Added output directory for orchestrator results