### PR TITLE
fix: correct state field access in debug logging

### DIFF
--- a/src/pdf_hunter/agents/report_generator/nodes.py
+++ b/src/pdf_hunter/agents/report_generator/nodes.py
@@ -27,9 +27,9 @@ async def determine_threat_verdict(state: OrchestratorState) -> dict:
         
         # Log key state information for debugging
         if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(f"PDF extraction results: {len(state.get('pdf_extraction_results', {}).get('extracted_images', []))} images")
-            logger.debug(f"File analysis: {state.get('file_analysis_report', {}).get('triage_classification_decision', 'No data')}")
-            logger.debug(f"URL investigation results: {len(state.get('url_investigation_results', []))} URLs analyzed")
+            logger.debug(f"Extracted images: {len(state.get('extracted_images', []))}")
+            logger.debug(f"Triage decision: {state.get('triage_classification_decision', 'No data')}")
+            logger.debug(f"URL analysis results: {len(state.get('link_analysis_final_reports', []))} URLs analyzed")
 
         # This node now ONLY uses the raw state, as it runs before the report is generated.
         # This fixes the KeyError and aligns with our desired logical flow.
@@ -56,7 +56,7 @@ async def determine_threat_verdict(state: OrchestratorState) -> dict:
         return {"errors": [error_msg]}
 
 
-async def generate_final_report(state: OrchestratorState) -> dict:
+async def generate_final_report(state: OrchestratorState):
     """
     Generate a comprehensive final report summarizing all findings.
     Node to create a comprehensive Markdown report based on the full investigation state,
@@ -93,7 +93,7 @@ async def generate_final_report(state: OrchestratorState) -> dict:
         return {"errors": [error_msg]}
 
 
-async def save_analysis_results(state: OrchestratorState) -> dict:
+async def save_analysis_results(state: OrchestratorState):
     """
     Write the final report and state to files.
     """

--- a/src/pdf_hunter/agents/url_investigation/graph.py
+++ b/src/pdf_hunter/agents/url_investigation/graph.py
@@ -157,7 +157,7 @@ if __name__ == "__main__":
         if final_state.get("link_analysis_final_reports"):
             logger.info(f"Generated {len(final_state['link_analysis_final_reports'])} URL analysis reports")
             for i, report in enumerate(final_state["link_analysis_final_reports"]):
-                url = report.get("initial_url", {}).get("url", f"Report #{i}")
+                url = report.initial_url.url if hasattr(report, 'initial_url') else f"Report #{i}"
                 logger.info(f"Report for URL: {url}")
                 if logger.isEnabledFor(logging.DEBUG):
                     logger.debug(f"Report details: {report.model_dump_json(indent=2)}")


### PR DESCRIPTION
- report_generator: align field names with OrchestratorState schema
  - extracted_images instead of pdf_extraction_results
  - triage_classification_decision direct access instead of nested
  - link_analysis_final_reports instead of url_investigation_results

- url_investigation: fix Pydantic model attribute access
  - Use report.initial_url.url instead of report.get() dict access
  - URLAnalysisResult is a Pydantic model, not a dict

These fixes prevent KeyError exceptions when debug logging is enabled.