### PR TITLE
fix: Critical bug fixes and state schema improvements

### DIFF
--- a/src/pdf_hunter/agents/report_generator/graph.py
+++ b/src/pdf_hunter/agents/report_generator/graph.py
@@ -1,12 +1,10 @@
 from langgraph.graph import StateGraph, START, END
 from .nodes import generate_final_report, determine_threat_verdict, save_analysis_results
 from pdf_hunter.config import REPORT_GENERATION_CONFIG
+from .schemas import ReportGeneratorState, ReportGeneratorOutputState
 
-# The finalizer's state is the same as the Orchestrator's, so no need to redefine
-from ...orchestrator.schemas import OrchestratorState
-
-# We can use a simple builder here as the state is passed directly from the orchestrator
-report_generator_builder = StateGraph(OrchestratorState)
+# Report Generator with explicit output schema for state management
+report_generator_builder = StateGraph(ReportGeneratorState, output_schema=ReportGeneratorOutputState)
 
 report_generator_builder.add_node("generate_final_report", generate_final_report)
 report_generator_builder.add_node("determine_threat_verdict", determine_threat_verdict)

--- a/src/pdf_hunter/agents/report_generator/nodes.py
+++ b/src/pdf_hunter/agents/report_generator/nodes.py
@@ -5,14 +5,13 @@ from datetime import datetime
 from loguru import logger
 from langchain_core.messages import SystemMessage, HumanMessage
 from pdf_hunter.config import report_generator_llm, final_verdict_llm
-from pdf_hunter.orchestrator.schemas import OrchestratorState
+from .schemas import ReportGeneratorState, FinalVerdict
 from pdf_hunter.shared.utils.serializer import serialize_state_safely, dump_state_to_file
 from .prompts import REPORT_GENERATOR_SYSTEM_PROMPT, REPORT_GENERATOR_USER_PROMPT, REPORT_GENERATOR_VERDICT_SYSTEM_PROMPT, REPORT_GENERATOR_VERDICT_USER_PROMPT
-from .schemas import FinalVerdict
 from pdf_hunter.config.execution_config import LLM_TIMEOUT_TEXT
 
 
-async def determine_threat_verdict(state: OrchestratorState) -> dict:
+async def determine_threat_verdict(state: ReportGeneratorState) -> dict:
     """
     Determine the overall security verdict based on all agent analyses.
     """
@@ -77,7 +76,7 @@ async def determine_threat_verdict(state: OrchestratorState) -> dict:
             timeout_seconds=LLM_TIMEOUT_TEXT,
             exc_info=True
         )
-        return {"errors": [error_msg]}
+        return {"errors": [[error_msg]]}
     except Exception as e:
         error_msg = f"Error in determine_threat_verdict: {type(e).__name__}: {e}"
         logger.error(
@@ -89,10 +88,10 @@ async def determine_threat_verdict(state: OrchestratorState) -> dict:
             event_type="ERROR",
             exc_info=True
         )
-        return {"errors": [error_msg]}
+        return {"errors": [[error_msg]]}
 
 
-async def generate_final_report(state: OrchestratorState):
+async def generate_final_report(state: ReportGeneratorState):
     """
     Generate a comprehensive final report summarizing all findings.
     Node to create a comprehensive Markdown report based on the full investigation state,
@@ -146,7 +145,7 @@ async def generate_final_report(state: OrchestratorState):
             timeout_seconds=LLM_TIMEOUT_TEXT,
             exc_info=True
         )
-        return {"errors": [error_msg]}
+        return {"errors": [[error_msg]]}
     except Exception as e:
         error_msg = f"Error in generate_final_report: {type(e).__name__}: {e}"
         logger.error(
@@ -158,11 +157,11 @@ async def generate_final_report(state: OrchestratorState):
             event_type="ERROR",
             exc_info=True
         )
-        return {"errors": [error_msg]}
+        return {"errors": [[error_msg]]}
 
 
 
-async def save_analysis_results(state: OrchestratorState):
+async def save_analysis_results(state: ReportGeneratorState):
     """
     Write the final report and state to files.
     """
@@ -234,4 +233,4 @@ async def save_analysis_results(state: OrchestratorState):
     except Exception as e:
         error_msg = f"Error in save_analysis_results: {e}"
         logger.error(error_msg, agent="ReportGenerator", node="save_analysis_results", event_type="ERROR", exc_info=True)
-        return {"errors": [error_msg]}
+        return {"errors": [[error_msg]]}

--- a/src/pdf_hunter/agents/report_generator/schemas.py
+++ b/src/pdf_hunter/agents/report_generator/schemas.py
@@ -1,7 +1,13 @@
-from typing import Annotated, List, Literal
+from typing import Annotated, List, Literal, Dict, Optional
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, NotRequired
 import operator
+
+# Import the types we need from other agents
+from ..file_analysis.schemas import EvidenceGraph, FinalReport
+from ..image_analysis.schemas import ImageAnalysisReport
+from ..url_investigation.schemas import URLAnalysisResult
+from ..pdf_extraction.schemas import ExtractedImage, ExtractedURL, PDFHashData
 
 
 class FinalVerdict(BaseModel):
@@ -11,11 +17,46 @@ class FinalVerdict(BaseModel):
     reasoning: str = Field(..., description="A concise synthesis explaining the most critical evidence and logic that led to the final verdict.")
 
 
-class ReportGeneratorState(TypedDict):
-    """The state for the Report Generator agent's internal graph."""
-    # This state will be merged with the main OrchestratorState
+class ReportGeneratorOutputState(TypedDict):
+    """Output state for Report Generator - what it produces."""
     final_report: NotRequired[str]
     final_verdict: NotRequired[FinalVerdict]
-    errors: Annotated[List[str], operator.add]
+    errors: Annotated[List[list], operator.add]
+
+
+class ReportGeneratorState(TypedDict):
+    """The complete state for the Report Generator agent's internal graph."""
+    # Session info
+    # --- Initial User Inputs ---
+    file_path: str
     output_directory: str
-    session_id: str        # Added for session management
+    number_of_pages_to_process: int
+    pages_to_process: Optional[List[int]]
+    additional_context: NotRequired[Optional[str]]
+    session_id: NotRequired[Optional[str]]
+
+    pdf_hash: Optional[PDFHashData]
+    page_count: Optional[int]
+
+    # --- Results from Preprocessing Agent ---
+    extracted_images: List[ExtractedImage]
+    extracted_urls: List[ExtractedURL]
+
+    # --- Results from Visual Analysis Agent ---
+    visual_analysis_report: NotRequired[ImageAnalysisReport]
+
+    # --- Results from Static Analysis Agent ---
+    structural_summary: Dict[str, str]
+    master_evidence_graph: NotRequired[EvidenceGraph]
+    triage_classification_decision: NotRequired[str]
+    triage_classification_reasoning: NotRequired[str]
+    static_analysis_final_report: NotRequired[FinalReport]
+
+    # --- Results from Link Analysis Agent ---
+    link_analysis_final_reports: Annotated[List[URLAnalysisResult], operator.add]
+
+        # --- Results from Finalization Agent ---
+    final_report: NotRequired[str]
+    final_verdict: NotRequired[FinalVerdict]
+
+    errors: Annotated[List[list], operator.add]

--- a/src/pdf_hunter/agents/url_investigation/cli.py
+++ b/src/pdf_hunter/agents/url_investigation/cli.py
@@ -138,7 +138,8 @@ async def main():
             else:
                 url = report.initial_url.url if hasattr(report, 'initial_url') else f"Report #{i}"
                 logger.info(f"Report for URL: {url}", agent="TestRunner", node="verify")
-                logger.debug(f"Report details: {report.model_dump_json(indent=2)}", agent="TestRunner", node="verify")
+                # Pass JSON as extra field to avoid format conflicts with {} in message string
+                logger.debug("Report details available", agent="TestRunner", node="verify", report_data=report.model_dump())
     else:
         logger.warning("No final report generated", agent="TestRunner", node="verify")
 

--- a/src/pdf_hunter/agents/url_investigation/graph.py
+++ b/src/pdf_hunter/agents/url_investigation/graph.py
@@ -51,7 +51,8 @@ async def conduct_link_analysis(state: dict):
         # We need to wrap it in a list so it gets aggregated via operator.add
         logger.info(f"✅ Link analysis complete for URL: {url}", agent="URLInvestigation", node="conduct_link_analysis_wrapper", event_type="WRAPPER_COMPLETE", url=url)
         return {
-            "link_analysis_final_reports": [result]  # This will be aggregated
+            "link_analysis_final_reports": [result["link_analysis_final_report"]],
+            "errors": result.get("errors", [])
         }
     
     except GraphRecursionError as e:

--- a/src/pdf_hunter/agents/url_investigation/nodes.py
+++ b/src/pdf_hunter/agents/url_investigation/nodes.py
@@ -74,12 +74,7 @@ async def investigate_url(state: URLInvestigatorState):
         task_id = f"url_{abs(hash(url_task.url))}"
         logger.debug(f"Generated task ID: {task_id}", agent="URLInvestigation", node="investigate_url")
 
-        # Create task-specific investigation directory under url investigation
-        url_investigation_dir = os.path.join(session_output_dir, "url_investigation", "investigations")
-        task_investigation_dir = os.path.join(url_investigation_dir, task_id)
-        await asyncio.to_thread(os.makedirs, task_investigation_dir, exist_ok=True)
-        logger.debug(f"Created investigation directory: {task_investigation_dir}", agent="URLInvestigation", node="investigate_url")
-
+        # MCP Playwright will automatically create task_url_{task_id} directory for screenshots and traces
         # Get the task-specific MCP session and load tools fresh each time
         from ...shared.utils.mcp_client import get_mcp_session
         
@@ -98,8 +93,6 @@ async def investigate_url(state: URLInvestigatorState):
         messages = state.get("investigation_logs", [])
         if not messages:
             logger.info("🆕 Starting new investigation chain", agent="URLInvestigation", node="investigate_url", event_type="CHAIN_START")
-            # Get absolute path for the task investigation directory
-            abs_task_investigation_dir = await asyncio.to_thread(os.path.abspath, task_investigation_dir)
             # Build context information
             source_context = getattr(url_task, 'source_context', 'PDF document')
             extraction_method = getattr(url_task, 'extraction_method', 'unknown method')
@@ -179,10 +172,7 @@ async def execute_browser_tools(state: URLInvestigatorState):
         # Generate the same task ID as used in investigate_url for session consistency
         task_id = f"url_{abs(hash(url_task.url))}"
 
-        # Create task-specific investigation directory under url investigation
-        url_investigation_dir = os.path.join(session_output_dir, "url_investigation", "investigations")
-        task_investigation_dir = os.path.join(url_investigation_dir, task_id)
-        await asyncio.to_thread(os.makedirs, task_investigation_dir, exist_ok=True)
+        # MCP Playwright will automatically create task_url_{task_id} directory for screenshots and traces
 
         async def execute_tools():
             from langchain_core.tools.base import ToolException
@@ -433,14 +423,9 @@ async def filter_high_priority_urls(state: URLInvestigationState):
     logger.info("🔎 Filtering high priority URLs from visual analysis", agent="URLInvestigation", node="filter_high_priority_urls", event_type="FILTER_START")
     
     try:
-        # Create url investigation investigations directory
-        session_output_dir = state.get("output_directory")
         high_priority_urls = []
         
-        if session_output_dir:
-            url_investigation_dir = os.path.join(session_output_dir, "url_investigation", "investigations")
-            await asyncio.to_thread(os.makedirs, url_investigation_dir, exist_ok=True)
-            logger.debug(f"Created URL investigation directory: {url_investigation_dir}", agent="URLInvestigation", node="filter_high_priority_urls")
+        # MCP Playwright will automatically create url_investigation/task_url_* directories for each investigation
 
         if "visual_analysis_report" in state and state["visual_analysis_report"]:
             visual_report = state["visual_analysis_report"]

--- a/src/pdf_hunter/orchestrator/graph.py
+++ b/src/pdf_hunter/orchestrator/graph.py
@@ -1,19 +1,19 @@
 from langgraph.graph import StateGraph, START, END
 
-from .schemas import OrchestratorState, OrchestratorInputState, OrchestratorOutputState
+from .schemas import OrchestratorState, OrchestratorInputState#, OrchestratorOutputState
+from .nodes import finalize_analysis
 from ..agents.pdf_extraction.graph import preprocessing_graph
 from ..agents.image_analysis.graph import visual_analysis_graph
 from ..agents.file_analysis.graph import static_analysis_graph
 from ..agents.url_investigation.graph import link_analysis_graph
 from ..agents.report_generator.graph import report_generator_graph
-from ..shared.utils.serializer import serialize_state_safely
 from ..config.logging_config import setup_logging
 from pdf_hunter.config import ORCHESTRATOR_CONFIG
 
 # Note: Logging will be configured in __main__ with session_id
 
 
-orchestrator_builder = StateGraph(OrchestratorState, input_schema=OrchestratorInputState, output_schema=OrchestratorOutputState)
+orchestrator_builder = StateGraph(OrchestratorState, input_schema=OrchestratorInputState)#, output_schema=OrchestratorOutputState)
 
 orchestrator_builder.add_node("PDF Extraction", preprocessing_graph)
 orchestrator_builder.add_node("File Analysis", static_analysis_graph)

--- a/src/pdf_hunter/orchestrator/schemas.py
+++ b/src/pdf_hunter/orchestrator/schemas.py
@@ -59,5 +59,5 @@ class OrchestratorInputState(TypedDict):
     session_id: NotRequired[Optional[str]]
 
 
-class OrchestratorOutputState(TypedDict):
-    final_verdict: NotRequired[FinalVerdict]
+# class OrchestratorOutputState(TypedDict):
+#     final_verdict: NotRequired[FinalVerdict]


### PR DESCRIPTION
Major Fixes:
- Fixed URL investigation double nesting bug in wrapper function
  * Extract URLAnalysisResult from subgraph result before wrapping
  * Prevents link_analysis_final_reports[0].link_analysis_final_report nesting
- Fixed Loguru JSON logging format conflicts in CLI
  * Pass JSON as extra fields instead of in message strings
  * Prevents {} braces in JSON from being treated as format placeholders
- Removed redundant folder creation in URL investigation
  * MCP Playwright auto-creates task_url_{task_id} directories
  * Removed 3 instances of manual investigations/ folder creation

State Schema Improvements:
- Added proper Report Generator state schemas (ReportGeneratorState, ReportGeneratorOutputState)
- Fixed error aggregation in Report Generator nodes (List[list] not List[str])
- Removed commented-out orchestrator finalize_analysis node

Documentation Updates:
- Updated .github/copilot-instructions.md with critical fixes section
- Documented double nesting bug and fix pattern
- Documented Loguru JSON logging best practices
- Documented Pydantic model access patterns
- Noted LangGraph Studio UI limitation with large state values

Related to: LangGraph subgraph output patterns, state management, logging best practices